### PR TITLE
FIX bug & discover Bluetooth Type

### DIFF
--- a/app/src/main/java/id/ghuniyu/sekitar/ui/activity/MainActivity.kt
+++ b/app/src/main/java/id/ghuniyu/sekitar/ui/activity/MainActivity.kt
@@ -357,7 +357,7 @@ class MainActivity : BaseActivity() {
     fun selfCheck(view: View) {
         val intent = Intent(
             Intent.ACTION_VIEW,
-            Uri.parse("https://ginanjarfm.github.io/${Formatter.redacted(selfCheck)}")
+            Uri.parse("https://ginanjarfm.github.io/covid19diagnose")
         )
         startActivity(intent)
     }


### PR DESCRIPTION
**FIX Self Check URL Bug**

Discover Bluetooth Type
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/1422134/77815304-4460aa80-70ec-11ea-8453-50b57eabc194.png">

Please continue this filter or save the types into DB.
```
                //FIXME: select specifics allowed type
                val allowedType:IntArray = intArrayOf(
                    BluetoothClass.Device.Major.AUDIO_VIDEO,
                    BluetoothClass.Device.Major.COMPUTER,
                    BluetoothClass.Device.Major.HEALTH,
                    BluetoothClass.Device.Major.IMAGING,
                    BluetoothClass.Device.Major.MISC,
                    BluetoothClass.Device.Major.NETWORKING,
                    BluetoothClass.Device.Major.PERIPHERAL,
                    BluetoothClass.Device.Major.PHONE,
                    BluetoothClass.Device.Major.TOY,
                    BluetoothClass.Device.Major.UNCATEGORIZED,
                    BluetoothClass.Device.Major.WEARABLE
                )
                if (!allowedType.contains(device.bluetoothClass.majorDeviceClass)) return
```